### PR TITLE
parametro consertado

### DIFF
--- a/EasyBank/Loan.cs
+++ b/EasyBank/Loan.cs
@@ -87,7 +87,7 @@
 
             else
             {
-                var finalInterestValue = AmountInterest(qtdParcels);
+                var finalInterestValue = AmountInterest(loanValue);
 
                 var finalValue = loanValue + finalInterestValue;
 


### PR DESCRIPTION
O calculo do juros no emprestimo estava usando a escolha da parcela ao inves do valor, apenas apliquei o parametro correto