### PR TITLE
erro da poupança e mudança do tempo resolvido

### DIFF
--- a/EasyBank/Entities/Bill.cs
+++ b/EasyBank/Entities/Bill.cs
@@ -26,11 +26,18 @@
         public void RemoveBills(List<Bill> bills, int userID, List<Loan> loans, List<User> users)
         {
             var bill = bills.FindAll(x => x.OwnerID == userID);
-
             var loanBill = bills.Find(x => x.Name == "EMPRÉSTIMO" && x.OwnerID == userID);
+            var user = users.Find(x => x.Id == userID);
 
             if (loanBill != null)
-                Loan.CheckAndRemoveLoan(loans, users, userID);
+            {
+                if (loanBill.RemainParcels <= 1)
+                {
+                    var loan = loans.Find(x => x.OwnerID == userID);
+                    user.OpenLoan = false;
+                    loans.Remove(loan);
+                }
+            }
 
             for (int i = 0; i < bill.Count; i++)
             {

--- a/EasyBank/Entities/CreditCard.cs
+++ b/EasyBank/Entities/CreditCard.cs
@@ -155,18 +155,21 @@ namespace EasyBank.Entities
         }
         public void MonthlyAction(List<CreditCard> creditCards, List<User> users, List<Bill> bills, List<AutoDebit> autoDebits, int userID)
         {
-            var user = users.Find(x => x.Id == userID);
-            user.CurrentAccount += user.MonthlyIncome;
+            if (users.Exists(x => x.Id == userID))
+            {
+                var user = users.Find(x => x.Id == userID);
+                user.CurrentAccount += user.MonthlyIncome;
 
-            CreditCard creditCard = new CreditCard();
-            creditCard.IncrementMonthInvoice(bills, creditCards, userID);
+                CreditCard creditCard = new CreditCard();
+                creditCard.IncrementMonthInvoice(bills, creditCards, userID);
 
-            Bill bill = new Bill();
-            if (bill.HasAutoDebitActivated(autoDebits, userID) == true)
-                AutoDebitPaymentAutomatic(autoDebits, users, bills, userID);
+                Bill bill = new Bill();
+                if (bill.HasAutoDebitActivated(autoDebits, userID) == true)
+                    AutoDebitPaymentAutomatic(autoDebits, users, bills, userID);
 
-            else if (HasPendingPayments(bills, userID) == true)
-                Message.GeneralThread("Novas Faturas, vá até a opção de Pagar Fatura em seu perfil",1000);
+                else if (HasPendingPayments(bills, userID) == true)
+                    Message.GeneralThread("Novas Faturas, vá até a opção de Pagar Fatura em seu perfil", 1000);
+            }
         }
     }
 }

--- a/EasyBank/Entities/Loan.cs
+++ b/EasyBank/Entities/Loan.cs
@@ -16,6 +16,7 @@ namespace EasyBank.Entities
             OwnerID = ownerID;
             Id = _id;
             Open = _open;
+            RemainParcels = _parcels;
         }
         public Loan()
         {
@@ -130,24 +131,6 @@ namespace EasyBank.Entities
                 ValueParcel = finalValue / qtdParcels,
                 RemainParcels = qtdParcels,
             });
-        }
-        public static void CheckAndRemoveLoan(List<Loan> loans, List<User> users, int userID)
-        {
-            var loan = loans.Find(x => x.OwnerID == userID);
-            var user = users.Find(x => x.Id == userID);
-
-            if (loan != null)
-            {
-                if (loan.RemainParcels <= 1)
-                {
-                    user.OpenLoan = false;
-                    loans.Remove(loan);
-                }
-            }
-        }
-        public void MonthlyAction(List<Loan> loans, List<User> users, int userID)
-        {
-            CheckAndRemoveLoan(loans, users, userID);
         }
     }
 }

--- a/EasyBank/Menu/Program.cs
+++ b/EasyBank/Menu/Program.cs
@@ -19,7 +19,7 @@ while (true)
 {
     string[] standardAdress = { "Blumenau", "SC", "Ponta Aguda", "AV Brasil", "788", "SENAC" };
     var userStantard = new User("Victor", "26/02/2004", "13991256286", "VICTOR@GMAIL.COM", // Usuario padrão para economizar tempo
-        "1234", "6324587419", "745896245", 1500, standardAdress, GeneralValidator.ID_AUTOINCREMENT(users), new Adress(), "0000");
+        "1234", "632.458.740-19", "745896245", 1500, standardAdress, GeneralValidator.ID_AUTOINCREMENT(users), new Adress(), "0000");
 
     users.Add(userStantard);
 

--- a/EasyBank/Services/MonthTimer.cs
+++ b/EasyBank/Services/MonthTimer.cs
@@ -51,7 +51,6 @@ namespace EasyBank.Services
         {
             _CreditCard.MonthlyAction(creditCards, users, bills, autoDebits, userID);
             _Saving.MonthlyAction(savings, userID);
-            _Loan.MonthlyAction(loans, users, userID);
         }
     }
 }


### PR DESCRIPTION
1. Estava sendo possivel efetuar outro emprestimo tendo um em aberto
2. Ao apagar a conta a mudança do tempo do cartao de credito tentava efetuar a ação do usuario deletado